### PR TITLE
Modify Azure Collector link and remove deprecated collector link

### DIFF
--- a/content/ko/docs/guides/plugins/asset-inventory-collector.md
+++ b/content/ko/docs/guides/plugins/asset-inventory-collector.md
@@ -24,8 +24,7 @@ description: >
 | AWS Cloud Services collector | https://github.com/cloudforet-io/plugin-aws-cloud-service-inven-collector/blob/master/docs/ko/GUIDE.md |
 | AWS EC2 Compute collector | https://github.com/cloudforet-io/plugin-aws-ec2-inven-collector/blob/master/docs/ko/GUIDE.md |
 | AWS Personal Health Dashboard collector |https://github.com/cloudforet-io/plugin-aws-phd-inven-collector/blob/master/docs/ko/GUIDE.md|
-| AWS Trusted Advisor collector | https://github.com/cloudforet-io/plugin-aws-trusted-advisor-inven-collector/blob/master/docs/ko/GUIDE.md
-| Azure Cloud Service collector |https://github.com/cloudforet-io/plugin-azure-cloud-service-inven-collector/blob/master/docs/ko/GUIDE.md|
-| Azure VM collector |https://github.com/cloudforet-io/plugin-azure-vm-inven-collector/blob/master/docs/ko/GUIDE.md|
+| AWS Trusted Advisor collector | https://github.com/cloudforet-io/plugin-aws-trusted-advisor-inven-collector/blob/master/docs/ko/GUIDE.md|
+| Azure Cloud collector |https://github.com/cloudforet-io/plugin-azure-inven-collector/blob/master/docs/ko/GUIDE.md|
 | Google Cloud collector |https://github.com/cloudforet-io/plugin-google-cloud-inven-collector/blob/master/docs/ko/GUIDE.md|
 | Monitoring Metric Collector of Collected Resources |https://github.com/cloudforet-io/plugin-monitoring-metric-inven-collector/blob/master/docs/ko/GUIDE.md|


### PR DESCRIPTION
### Task
- [ ] New Documentation
- [x] Fix Content
- [ ] Etc (CI/CD Workflow)

### Description
- modify Azure Collector link and remove deprecated collector link
  - `Azure VM collector` was deprecated so we deleted this section
  - modify `Azure Cloud Service collector` to `Azure Cloud collector` and updated github link