### PR TITLE
Fix theme bug

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,7 +22,6 @@
 <meta name="Keywords" content={{ T "meta_keywords" }}>
 <meta name="Author" content={{ T "meta_author" }}>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 


### PR DESCRIPTION
_internal/google_news.html was removed from Hugo updates

https://discourse.gohugo.io/t/page-render-error/43594

execute of template failed: template: posts/single.html:4:11: executing "posts/single.html" at <partial "head.html" .>: error calling partial: execute of template failed: html/template:partials/head.html:40:12: no such template "_internal/google_news.html"

### Task
- [ ] New Documentation
- [ ] Fix Content
- [x] Etc (CI/CD Workflow)

### Description

### Known Issues
