### PR TITLE
Update Get Started link

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -5,7 +5,7 @@ title: Home
 <h2>Manage All<br />Cloud Resources<br />in <em>One Platform</em></h2>
 <p class="sub-title">Cloudforet is an Open Source Platform for Enabling Integrated Management of Multi-Clouds.</p>
 <div class="btn-group">
-    <a href="https://cloudforet.io/docs/setup_operation/install_guide/" class="btn-link btn-link-green" target="_blank"><span>Get Started</span></a>
+    <a href="https://cloudforet.io/docs/setup_operation/quick_install/" class="btn-link btn-link-green" target="_blank"><span>Get Started</span></a>
     <a href="https://github.com/cloudforet-io" class="btn-link btn-link-gradient link-github" target="_blank">GitHub</a>
 </div>
 {{% /blocks/section %}}

--- a/content/ja/_index.html
+++ b/content/ja/_index.html
@@ -5,7 +5,7 @@ title: Home
 <h2>すべてのクラウドリソースを<br /><em>一つのプラットフォーム</em>で管理する</h2>
 <p class="sub-title">Cloudforetはマルチクラウドの統合管理する<br/>オープンソースプラットフォームです。</p>
 <div class="btn-group">
-    <a href="https://cloudforet.io/docs/setup_operation/install_guide/" class="btn-link btn-link-green" target="_blank"><span>初めてみましょう</span></a>
+    <a href="https://cloudforet.io/docs/setup_operation/quick_install/" class="btn-link btn-link-green" target="_blank"><span>初めてみましょう</span></a>
     <a href="https://github.com/cloudforet-io" class="btn-link btn-link-gradient link-github" target="_blank">GitHub</a>
 </div>
 {{% /blocks/section %}}

--- a/content/ko/_index.html
+++ b/content/ko/_index.html
@@ -5,7 +5,7 @@ title: Home
 <h2>멀티클라우드 관리를 하나로 <br /><em>Cloudforet</em></h2>
 <p class="sub-title">클라우드포레는 멀티 클라우드 환경을 위한 통합 관리하는 오픈소스 플랫폼입니다.</p>
 <div class="btn-group">
-    <a href="https://cloudforet.io/docs/setup_operation/install_guide/" class="btn-link btn-link-green" target="_blank"><span>설치하기</span></a>
+    <a href="https://cloudforet.io/docs/setup_operation/quick_install/" class="btn-link btn-link-green" target="_blank"><span>설치하기</span></a>
     <a href="https://github.com/cloudforet-io" class="btn-link btn-link-gradient link-github" target="_blank">GitHub</a>
 </div>
 {{% /blocks/section %}}


### PR DESCRIPTION
The "Get Started" link is target to "Quick Install" not Full Installation

### Task
- [ ] New Documentation
- [x] Fix Content
- [ ] Etc (CI/CD Workflow)

### Description

### Known Issues
