### PR TITLE
Correct Helm version typo

### DIFF
--- a/content/en/docs/setup_operation/quick_install/_index.md
+++ b/content/en/docs/setup_operation/quick_install/_index.md
@@ -32,7 +32,7 @@ This Guide is not for production, but for developer only.
   - Requires minimum **Kubernetes version of 1.21+**.  
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Helm](https://helm.sh/docs/intro/install/) 
-  - Requires minimum **Helm version of 3.2.0+**.
+  - Requires minimum **Helm version of 3.11.0+**.
   - If you want to learn more about Helm, refer to [this](https://helm.sh/).
 
 

--- a/content/en/docs/setup_operation/quick_install/_index.md
+++ b/content/en/docs/setup_operation/quick_install/_index.md
@@ -32,7 +32,7 @@ This Guide is not for production, but for developer only.
   - Requires minimum **Kubernetes version of 1.21+**.  
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Helm](https://helm.sh/docs/intro/install/) 
-  - Requires minimum **Helm version of 3.11.0+**.
+  - Requires minimum **Helm version of 3.2.0+**.
   - If you want to learn more about Helm, refer to [this](https://helm.sh/).
 
 


### PR DESCRIPTION
Correcting the helm version typo from 3.2.0+ to 3.11.0+ in the minikube installation setup

### Task
- [ ] New Documentation
- [x] Fix Content
- [ ] Etc (CI/CD Workflow)

### Description

### Known Issues
