### PR TITLE
Added warning before step 5.  

### DIFF
--- a/content/en/docs/setup_operation/quick_install/_index.md
+++ b/content/en/docs/setup_operation/quick_install/_index.md
@@ -146,6 +146,8 @@ statistics-scheduler-586875947c-8zfqg     0/1     Error              3 (30s ago)
 statistics-worker-68d646fc7-knbdr         1/1     Running            0             58s
 supervisor-scheduler-6744657cb6-tpf78     2/2     Running            0             59s
 ```
+> To execute the commands below, every POD except xxxx-scheduler-yyyy must have a Running status.
+
 ### 5) Initialize the Configuration  
 First, download the [initializer.yaml](examples/initializer.yaml) file.
 


### PR DESCRIPTION
Fixes #174
### Task
- [ ] New Documentation
- [x] Fix Content
- [ ] Etc (CI/CD Workflow)

### Description
In order to avoid any error in step 5 in the installation guide a warning is added describing that every pod should have a running status except the pods of type  xxxx-scheduler-yyyy.

### Known Issues
