### PR TITLE
Correcting the redundant test environment - Ubuntu 22.04

### DIFF
--- a/content/en/docs/setup_operation/quick_install/_index.md
+++ b/content/en/docs/setup_operation/quick_install/_index.md
@@ -16,7 +16,6 @@ This Guide is not for production, but for developer only.
 | Distro     | Status       |
 | ---        | ---           |
 | Ubuntu 20.04    |  Not Tested   |
-| Ubuntu 22.04    |  Not Tested   |
 | Amazon Linux 2  |  Not Tested      |
 | Amazon Linux 2023  | Not Tested    |
 | macOS (Apple Silicon, M1) | Not Tested |


### PR DESCRIPTION
Removing the redundant environment, Ubuntu 22.04.

### Task
- [ ] New Documentation
- [x] Fix Content
- [ ] Etc (CI/CD Workflow)

### Description
Removing the redundant verification environments - Ubuntu 22.04

### Known Issues
Ubuntu 22.04 was redundant and was repeated twice.