### PR TITLE
added blog link in windows installation

### DIFF
--- a/content/en/docs/setup_operation/quick_install/_index.md
+++ b/content/en/docs/setup_operation/quick_install/_index.md
@@ -21,7 +21,7 @@ Note :- This Guide is not for production, but for developer only.
 | Amazon Linux 2023  | Not Tested    |    |
 | macOS (Apple Silicon, M1) | Verified |   |
 | macOS (Apple Silicon, M2) | Verified   |   |
-| Windows         |  Not Tested   |       |
+| Windows         |  Verified   |  https://medium.com/@ayushsharma2267410/installation-of-cloudforet-in-windows-8c4a10c9a65f     |
 
 ## Overview
 


### PR DESCRIPTION
### Task
- [ ] New Documentation
-  Fix Content
- [ ] Etc (CI/CD Workflow)

### Description
Fixes #184 
Added the blog link for installation in windows in docs under the column Link(ex. Blog)

### Known Issues
